### PR TITLE
Fix breakage due to component-count method not available error

### DIFF
--- a/bz.js
+++ b/bz.js
@@ -24,7 +24,7 @@ BugzillaClient.prototype = {
     this.APIRequest('/count', 'GET', callback, 'data', null, params);
   },
 
-  countBugsX : function(params, callback) {
+  countComponents : function(params, callback) {
     this.APIRequest('/count', 'GET', callback, null, null, params);
   },
 

--- a/datapull.js
+++ b/datapull.js
@@ -136,7 +136,7 @@ function createUser(userObj, private, save) {
 
     pending++;
     // Calculate Component
-    bugzilla.countBugsX({
+    bugzilla.countComponents({
         x_axis_field: "product",
         y_axis_field: "component",
         "field0-0-0": "attachment.is_patch",

--- a/install-example.sh
+++ b/install-example.sh
@@ -6,4 +6,4 @@ username = # your username
 password = # your password
 git config remote.origin.url https://${username}:${password}@github.com/${username}/leaderchalk.git
 npm install bz
-cp bz.js node_modules/bz/lib
+cp bz.js node_modules/bz/


### PR DESCRIPTION
Custom BZ lib was being copied over to wrong path that it was expected, leading to unavailability of the custom method (component counts).

Also, renamed `countBugsX` to `countComponents` to make it more intuitive to work with.
