### PR TITLE
Exclude WONTFIX/DUPLUCATE and other resolutions

### DIFF
--- a/datapull.js
+++ b/datapull.js
@@ -120,10 +120,12 @@ function createUser(userObj, private, save) {
     });
 
     pending++;
-    // Count assigned
+    // Count assigned bugs that are not WONTFIXed or DUPLICATEd
     bugzilla.countBugs({
         email1: email,
-        email1_assigned_to: 1
+        email1_assigned_to: 1,
+        status: ['UNCONFIRMED','NEW','ASSIGNED','REOPENED','RESOLVED','VERIFIED'],
+        resolution: ['---','FIXED']
     }, function(error, assigned) {
         if (error) {
             errorHandler(error);


### PR DESCRIPTION
Sometimes one is assigned to a bug which has been marked WONTFIX or INVALID or DUPLICATE. In such a case, it probably should not count as part of the leaderboard, since it's never going to be fixed.

This PR restricts the count of "assigned" bugs to open bugs which either have no resolution, or are FIXED.
